### PR TITLE
Change Poliwag's menu/overworld sprite palettes from RED to BLUE

### DIFF
--- a/data/pokemon/menu_mon_pals.asm
+++ b/data/pokemon/menu_mon_pals.asm
@@ -76,7 +76,7 @@ MenuMonPals::
 	menu_mon_pals BROWN,  BROWN  ; PRIMEAPE
 	menu_mon_pals RED,    BROWN  ; GROWLITHE
 	menu_mon_pals RED,    BROWN  ; ARCANINE
-	menu_mon_pals BLUE,   BLUE   ; POLIWAG
+	menu_mon_pals BLUE,   TEAL   ; POLIWAG
 	menu_mon_pals BLUE,   BLUE   ; POLIWHIRL
 	menu_mon_pals BLUE,   TEAL   ; POLIWRATH
 	menu_mon_pals BROWN,  PURPLE ; ABRA

--- a/data/pokemon/menu_mon_pals.asm
+++ b/data/pokemon/menu_mon_pals.asm
@@ -76,7 +76,7 @@ MenuMonPals::
 	menu_mon_pals BROWN,  BROWN  ; PRIMEAPE
 	menu_mon_pals RED,    BROWN  ; GROWLITHE
 	menu_mon_pals RED,    BROWN  ; ARCANINE
-	menu_mon_pals RED,    RED    ; POLIWAG
+	menu_mon_pals BLUE,   BLUE   ; POLIWAG
 	menu_mon_pals BLUE,   BLUE   ; POLIWHIRL
 	menu_mon_pals BLUE,   TEAL   ; POLIWRATH
 	menu_mon_pals BROWN,  PURPLE ; ABRA


### PR DESCRIPTION
Hello!

I noticed Poliwag's colors were red, so I switched them to blue.

# Before
<img width="811" alt="Screen Shot 2024-02-10 at 7 49 50 PM" src="https://github.com/fellowship-of-the-roms/pokecrystal/assets/49461754/c94b38c5-3e93-4eae-bb63-9831a704567c">

# After
<img width="811" alt="Screen Shot 2024-02-10 at 7 45 42 PM" src="https://github.com/fellowship-of-the-roms/pokecrystal/assets/49461754/f6bc026f-01b0-46f9-ab3b-e2d8270f8ba5">

If you want me to make any changes, just let me know and I'd be happy to make the updates!